### PR TITLE
Yield Protocol Actions

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,7 @@ optimizer_runs = 8000
 # Gas reporting
 gas_reports = ["*"]
 
-verbosity = 1
+verbosity = 3
 
 sender = '0xf1A7dA0000000000000000000000000000000000'
 tx_origin = '0xf1A7dA0000000000000000000000000000000000'

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,7 +21,7 @@ fi
 if [ "$1" == "local" ]; then
   forge test --ffi --chain-id 99 --match-path $(pwd)/src/test/local --fork-url http://localhost:8545
 elif [ "$1" == "mainnet" ]; then
-  forge test --chain-id 99 --fork-url https://eth-$1.alchemyapi.io/v2/${ALCHEMY_API_KEY} --fork-block-number 13627845
+  forge test --chain-id 99 --fork-url https://eth-$1.alchemyapi.io/v2/${ALCHEMY_API_KEY} --fork-block-number 13700000
 else
   ETH_RPC_URL=https://eth-$1.alchemyapi.io/v2/${ALCHEMY_API_KEY}
   forge test --fork-url $ETH_RPC_URL

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -19,7 +19,7 @@ if [[ ! " ${networks[*]} " =~ " $1 " ]]; then
 fi
 
 if [ "$1" == "local" ]; then
-  forge test --ffi --chain-id 99 --match-path $(pwd)/src/test/local --fork-url http://localhost:8545
+  forge test --ffi --chain-id 99 --match-path src/test/local
 elif [ "$1" == "mainnet" ]; then
   forge test --chain-id 99 --fork-url https://eth-$1.alchemyapi.io/v2/${ALCHEMY_API_KEY} --fork-block-number 13700000
 else

--- a/src/test/local/VaultFYActions.t.sol
+++ b/src/test/local/VaultFYActions.t.sol
@@ -104,11 +104,15 @@ contract VaultEPTActions_UnitTest is DSTest {
 
     function test_underlierToFYTokenOverflow() public {
         uint256 MAX = type(uint128).max;
-        assertEq(VaultActions.underlierToFYToken(MAX, address(yieldSpace)), 0);
+        bytes memory customError = abi.encodeWithSignature("VaultFYActions__underlierToFYToken__overflow()");
+        hevm.expectRevert(customError);
+        VaultActions.underlierToFYToken(MAX, address(yieldSpace));
     }
 
     function test_fyTokenToUnderlierOverflow() public {
         uint256 MAX = type(uint128).max;
-        assertEq(VaultActions.fyTokenToUnderlier(MAX, address(yieldSpace)), 0);
+        bytes memory customError = abi.encodeWithSignature("VaultFYActions__fyTokenToUnderlier__overflow()");
+        hevm.expectRevert(customError);
+        VaultActions.fyTokenToUnderlier(MAX, address(yieldSpace));
     }
 }

--- a/src/test/local/VaultFYActions.t.sol
+++ b/src/test/local/VaultFYActions.t.sol
@@ -103,16 +103,14 @@ contract VaultEPTActions_UnitTest is DSTest {
     }
 
     function test_underlierToFYTokenOverflow() public {
-        uint256 MAX = type(uint128).max;
-        bytes memory customError = abi.encodeWithSignature("VaultFYActions__underlierToFYToken__overflow()");
+        bytes memory customError = abi.encodeWithSignature("VaultFYActions__underlierToFYToken_overflow()");
         hevm.expectRevert(customError);
-        VaultActions.underlierToFYToken(MAX, address(yieldSpace));
+        VaultActions.underlierToFYToken(type(uint128).max, address(yieldSpace));
     }
 
     function test_fyTokenToUnderlierOverflow() public {
-        uint256 MAX = type(uint128).max;
-        bytes memory customError = abi.encodeWithSignature("VaultFYActions__fyTokenToUnderlier__overflow()");
+        bytes memory customError = abi.encodeWithSignature("VaultFYActions__fyTokenToUnderlier_overflow()");
         hevm.expectRevert(customError);
-        VaultActions.fyTokenToUnderlier(MAX, address(yieldSpace));
+        VaultActions.fyTokenToUnderlier(type(uint128).max, address(yieldSpace));
     }
 }

--- a/src/test/local/VaultFYActions.t.sol
+++ b/src/test/local/VaultFYActions.t.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import {DSTest} from "ds-test/test.sol";
+
+import {IERC20} from "openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {MockProvider} from "mockprovider/MockProvider.sol";
+
+import {Codex} from "fiat/Codex.sol";
+import {IVault} from "fiat/interfaces/IVault.sol";
+import {IMoneta} from "fiat/interfaces/IMoneta.sol";
+import {Moneta} from "fiat/Moneta.sol";
+import {FIAT} from "fiat/FIAT.sol";
+import {WAD, toInt256, wmul, wdiv, sub, add} from "fiat/utils/Math.sol";
+
+import {VaultFYActions} from "../../vault/VaultFYActions.sol";
+import {Hevm} from "../utils/Hevm.sol";
+
+contract YieldSpaceMock {
+    function sellBasePreview(uint128 baseIn) external pure returns (uint128) {
+        return (baseIn * 102) / 100;
+    }
+
+    function sellBase(address, uint128 min) external pure returns (uint128) {
+        return (min * 102) / 100;
+    }
+
+    function sellFYTokenPreview(uint128 fyTokenIn) external pure returns (uint128) {
+        return (fyTokenIn * 99) / 100;
+    }
+
+    function sellFYToken(address, uint128 min) external pure returns (uint128) {
+        return (min * 99) / 100;
+    }
+}
+
+contract VaultEPTActions_UnitTest is DSTest {
+    MockProvider codex;
+    MockProvider moneta;
+    MockProvider publican;
+    MockProvider mockCollateral;
+    MockProvider mockVault;
+    VaultFYActions VaultActions;
+    MockProvider fiat;
+    YieldSpaceMock yieldSpace;
+    MockProvider ccp;
+
+    Hevm internal hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    address me = address(this);
+    bytes32 poolId = bytes32("somePoolId");
+
+    address internal underlierUSDC = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48); // USDC
+    address internal fyUSDC06 = address(0x4568bBcf929AB6B4d716F2a3D5A967a1908B4F1C); // FYUSDC06
+
+    uint256 underlierScale = uint256(1e6);
+    uint256 tokenScale = uint256(1e6);
+    uint256 percentFee = 1e16;
+
+    function setUp() public {
+        fiat = new MockProvider();
+        codex = new MockProvider();
+        moneta = new MockProvider();
+        publican = new MockProvider();
+        mockCollateral = new MockProvider();
+        mockVault = new MockProvider();
+        ccp = new MockProvider();
+        yieldSpace = new YieldSpaceMock();
+
+        VaultActions = new VaultFYActions(address(codex), address(moneta), address(fiat), address(publican));
+
+        mockVault.givenSelectorReturnResponse(
+            IVault.token.selector,
+            MockProvider.ReturnData({success: true, data: abi.encode(fyUSDC06)}),
+            false
+        );
+
+        mockVault.givenSelectorReturnResponse(
+            IVault.underlierToken.selector,
+            MockProvider.ReturnData({success: true, data: abi.encode(underlierUSDC)}),
+            false
+        );
+
+        mockVault.givenSelectorReturnResponse(
+            IVault.underlierScale.selector,
+            MockProvider.ReturnData({success: true, data: abi.encode(uint256(1e6))}),
+            false
+        );
+
+        mockVault.givenSelectorReturnResponse(
+            IVault.tokenScale.selector,
+            MockProvider.ReturnData({success: true, data: abi.encode(uint256(1e6))}),
+            false
+        );
+    }
+
+    function test_underlierToFYToken() public {
+        assertEq(VaultActions.underlierToFYToken(1e6, address(yieldSpace)), yieldSpace.sellBasePreview(1e6));
+    }
+
+    function test_fyTokenToUnderlier() public {
+        assertEq(VaultActions.fyTokenToUnderlier(1e6, address(yieldSpace)), yieldSpace.sellFYTokenPreview(1e6));
+    }
+
+    function test_underlierToFYTokenOverflow() public {
+        uint256 MAX = type(uint128).max;
+        assertEq(VaultActions.underlierToFYToken(MAX, address(yieldSpace)), 0);
+    }
+
+    function test_fyTokenToUnderlierOverflow() public {
+        uint256 MAX = type(uint128).max;
+        assertEq(VaultActions.fyTokenToUnderlier(MAX, address(yieldSpace)), 0);
+    }
+}

--- a/src/test/rpc/VaultFYActions.t.sol
+++ b/src/test/rpc/VaultFYActions.t.sol
@@ -169,14 +169,12 @@ contract VaultFYActions_RPC_tests is DSTest {
     function _getSwapParams(
         address assetIn,
         address assetOut,
-        uint256 minOutput,
-        uint256 approveAmount
+        uint256 minOutput
     ) internal view returns (VaultFYActions.SwapParams memory swapParams) {
         swapParams.yieldSpacePool = fyUSDC04LP;
         swapParams.assetIn = assetIn;
         swapParams.assetOut = assetOut;
         swapParams.minAssetOut = minOutput;
-        swapParams.approve = approveAmount;
     }
 
     function setUp() public {
@@ -254,7 +252,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             amount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(me), meInitialBalance - amount);
@@ -280,7 +278,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             amount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(address(kakaroto)), kakarotoInitialBalance - amount);
@@ -303,7 +301,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             amount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, amount)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(address(userProxy)), userProxyInitialBalance - amount);
@@ -326,7 +324,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             amount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, amount)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(address(userProxy)), userProxyInitialBalance - amount);
@@ -345,7 +343,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
@@ -355,12 +353,7 @@ contract VaultFYActions_RPC_tests is DSTest {
         uint256 amount = 500 * ONE_USDC;
         uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC04LP);
 
-        VaultFYActions.SwapParams memory swapParams = _getSwapParams(
-            fyUSDC04,
-            address(underlierUSDC),
-            expectedDelta,
-            0
-        );
+        VaultFYActions.SwapParams memory swapParams = _getSwapParams(fyUSDC04, address(underlierUSDC), expectedDelta);
 
         _sellCollateralAndModifyDebt(address(vaultFY_USDC06), me, address(0), amount, 0, swapParams);
 
@@ -384,7 +377,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 kakarotoInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
@@ -394,12 +387,7 @@ contract VaultFYActions_RPC_tests is DSTest {
         uint256 amount = 500 * ONE_USDC;
         uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC04LP);
 
-        VaultFYActions.SwapParams memory swapParams = _getSwapParams(
-            fyUSDC04,
-            address(underlierUSDC),
-            expectedDelta,
-            0
-        );
+        VaultFYActions.SwapParams memory swapParams = _getSwapParams(fyUSDC04, address(underlierUSDC), expectedDelta);
 
         _sellCollateralAndModifyDebt(address(vaultFY_USDC06), address(kakaroto), address(0), amount, 0, swapParams);
 
@@ -419,7 +407,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
@@ -449,7 +437,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
@@ -479,7 +467,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = fiat.balanceOf(me);
@@ -501,7 +489,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 kakarotoInitialBalance = fiat.balanceOf(address(kakaroto));
@@ -530,7 +518,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = fiat.balanceOf(me);
@@ -552,7 +540,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         fiat.transfer(address(kakaroto), 500 * WAD);
@@ -583,7 +571,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         fiat.transfer(address(userProxy), 500 * WAD);
@@ -607,7 +595,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         fiat.transfer(address(userProxy), 500 * WAD);
@@ -645,7 +633,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(me), meInitialBalance - tokenAmount);
@@ -678,7 +666,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(address(kakaroto)), meInitialBalance - tokenAmount);
@@ -711,7 +699,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, previewOut)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(address(userProxy)), meInitialBalance - tokenAmount);
@@ -744,7 +732,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, previewOut)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(address(userProxy)), meInitialBalance - tokenAmount);
@@ -775,7 +763,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(kakaroto),
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(me), meInitialBalance - tokenAmount);
@@ -799,7 +787,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
@@ -814,8 +802,7 @@ contract VaultFYActions_RPC_tests is DSTest {
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
             fyUSDC04,
             address(underlierUSDC),
-            expectedDelta / 2,
-            expectedDelta
+            expectedDelta / 2
         );
 
         _sellCollateralAndModifyDebt(address(vaultFY_USDC06), me, me, amount, -toInt256(100 * WAD), swapParams);
@@ -839,7 +826,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
@@ -854,8 +841,7 @@ contract VaultFYActions_RPC_tests is DSTest {
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
             fyUSDC04,
             address(underlierUSDC),
-            expectedDelta / 2,
-            expectedDelta
+            expectedDelta / 2
         );
 
         _sellCollateralAndModifyDebt(
@@ -886,7 +872,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
@@ -903,8 +889,7 @@ contract VaultFYActions_RPC_tests is DSTest {
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
             fyUSDC04,
             address(underlierUSDC),
-            expectedDelta / 2,
-            expectedDelta
+            expectedDelta / 2
         );
 
         _sellCollateralAndModifyDebt(
@@ -935,7 +920,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
@@ -952,8 +937,7 @@ contract VaultFYActions_RPC_tests is DSTest {
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
             fyUSDC04,
             address(underlierUSDC),
-            expectedDelta / 2,
-            expectedDelta
+            expectedDelta / 2
         );
 
         _sellCollateralAndModifyDebt(address(vaultFY_USDC06), me, address(0), amount, -toInt256(100 * WAD), swapParams);
@@ -977,7 +961,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
@@ -994,8 +978,7 @@ contract VaultFYActions_RPC_tests is DSTest {
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
             fyUSDC04,
             address(underlierUSDC),
-            expectedDelta / 2,
-            expectedDelta
+            expectedDelta / 2
         );
 
         _sellCollateralAndModifyDebt(

--- a/src/test/rpc/VaultFYActions.t.sol
+++ b/src/test/rpc/VaultFYActions.t.sol
@@ -32,8 +32,8 @@ contract VaultFYActions_RPC_tests is DSTest {
     Hevm internal hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IERC20 internal underlierUSDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48); // USDC
     PRBProxyFactory internal prbProxyFactory;
-    address internal fyUSDC06 = address(0x4568bBcf929AB6B4d716F2a3D5A967a1908B4F1C);
-    address internal fyUSDC06LP = address(0xEf82611C6120185D3BF6e020D1993B49471E7da0);
+    address internal fyUSDC04 = address(0x30FaDeEaAB2d7a23Cb1C35c05e2f8145001fA533);
+    address internal fyUSDC04LP = address(0x407353d527053F3a6140AAA7819B93Af03114227);
 
     Codex internal codex;
     Publican internal publican;
@@ -172,7 +172,7 @@ contract VaultFYActions_RPC_tests is DSTest {
         uint256 minOutput,
         uint256 approveAmount
     ) internal view returns (VaultFYActions.SwapParams memory swapParams) {
-        swapParams.yieldSpacePool = fyUSDC06LP;
+        swapParams.yieldSpacePool = fyUSDC04LP;
         swapParams.assetIn = assetIn;
         swapParams.assetOut = assetOut;
         swapParams.minAssetOut = minOutput;
@@ -203,7 +203,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
         _mintUSDC(me, 2000000 * ONE_USDC);
 
-        address instance = vaultFactory.createVault(address(vaultFY_impl), abi.encode(fyUSDC06, address(collybus)));
+        address instance = vaultFactory.createVault(address(vaultFY_impl), abi.encode(fyUSDC04, address(collybus)));
 
         vaultFY_USDC06 = VaultFY(instance);
         codex.setParam(instance, "debtCeiling", uint256(1000 ether));
@@ -221,7 +221,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             abi.encodeWithSelector(underlierUSDC.approve.selector, address(userProxy), type(uint256).max)
         );
         // Collateral
-        IERC20(fyUSDC06).approve(address(userProxy), type(uint256).max);
+        IERC20(fyUSDC04).approve(address(userProxy), type(uint256).max);
         // FIAT
         fiat.approve(address(userProxy), type(uint256).max);
         kakaroto.externalCall(
@@ -244,9 +244,9 @@ contract VaultFYActions_RPC_tests is DSTest {
     function test_increaseCollateral_from_underlier() public {
         uint128 amount = 100 * uint128(ONE_USDC);
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
-        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -254,14 +254,14 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             amount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         assertEq(underlierUSDC.balanceOf(me), meInitialBalance - amount);
-        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= previewOut + vaultInitialBalance);
+        assertTrue(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)) >= previewOut + vaultInitialBalance);
         assertTrue(
             _collateral(address(vaultFY_USDC06), address(userProxy)) >=
-                initialCollateral + wdiv(previewOut, 10**IERC20Metadata(fyUSDC06).decimals())
+                initialCollateral + wdiv(previewOut, 10**IERC20Metadata(fyUSDC04).decimals())
         );
     }
 
@@ -270,9 +270,9 @@ contract VaultFYActions_RPC_tests is DSTest {
         underlierUSDC.transfer(address(kakaroto), amount);
 
         uint256 kakarotoInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
-        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -280,12 +280,12 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             amount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         assertEq(underlierUSDC.balanceOf(address(kakaroto)), kakarotoInitialBalance - amount);
-        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + previewOut);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertTrue(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + previewOut);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertTrue(_collateral(address(vaultFY_USDC06), address(userProxy)) >= initialCollateral + wadAmount);
     }
 
@@ -293,9 +293,9 @@ contract VaultFYActions_RPC_tests is DSTest {
         uint256 amount = 100 * ONE_USDC;
         underlierUSDC.transfer(address(userProxy), amount);
         uint256 userProxyInitialBalance = underlierUSDC.balanceOf(address(userProxy));
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
-        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -303,12 +303,12 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             amount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, amount)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, amount)
         );
 
         assertEq(underlierUSDC.balanceOf(address(userProxy)), userProxyInitialBalance - amount);
-        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertTrue(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertTrue(_collateral(address(vaultFY_USDC06), address(userProxy)) >= initialCollateral + wadAmount);
     }
 
@@ -316,9 +316,9 @@ contract VaultFYActions_RPC_tests is DSTest {
         uint256 amount = 100 * ONE_USDC;
         underlierUSDC.transfer(address(userProxy), amount);
         uint256 userProxyInitialBalance = underlierUSDC.balanceOf(address(userProxy));
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
-        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -326,18 +326,18 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             amount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, amount)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, amount)
         );
 
         assertEq(underlierUSDC.balanceOf(address(userProxy)), userProxyInitialBalance - amount);
-        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertTrue(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertTrue(_collateral(address(vaultFY_USDC06), address(userProxy)) >= initialCollateral + wadAmount);
     }
 
     function test_decreaseCollateral_get_underlier() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -345,18 +345,18 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
 
         uint256 amount = 500 * ONE_USDC;
-        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC04LP);
 
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
-            fyUSDC06,
+            fyUSDC04,
             address(underlierUSDC),
             expectedDelta,
             0
@@ -369,14 +369,14 @@ contract VaultFYActions_RPC_tests is DSTest {
         emit log_named_uint("balance", underlierUSDC.balanceOf(me));
 
         assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + expectedDelta);
-        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
     }
 
     function test_decreaseCollateral_send_underlier_to_user() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -384,18 +384,18 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 kakarotoInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
 
         uint256 amount = 500 * ONE_USDC;
-        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC04LP);
 
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
-            fyUSDC06,
+            fyUSDC04,
             address(underlierUSDC),
             expectedDelta,
             0
@@ -404,14 +404,14 @@ contract VaultFYActions_RPC_tests is DSTest {
         _sellCollateralAndModifyDebt(address(vaultFY_USDC06), address(kakaroto), address(0), amount, 0, swapParams);
 
         assertTrue(underlierUSDC.balanceOf(address(kakaroto)) >= kakarotoInitialBalance + expectedDelta);
-        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
     }
 
     function test_decreaseCollateral_redeem_underlier() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -419,11 +419,11 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
 
         uint256 amount = 500 * ONE_USDC;
@@ -434,14 +434,14 @@ contract VaultFYActions_RPC_tests is DSTest {
         _redeemCollateralAndModifyDebt(address(vaultFY_USDC06), me, address(0), amount, 0);
 
         assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + amount);
-        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
     }
 
     function test_decreaseCollateral_redeem_underlier_to_user() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -449,11 +449,11 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
 
         uint256 amount = 500 * ONE_USDC;
@@ -464,14 +464,14 @@ contract VaultFYActions_RPC_tests is DSTest {
         _redeemCollateralAndModifyDebt(address(vaultFY_USDC06), address(kakaroto), address(0), amount, 0);
 
         assertTrue(underlierUSDC.balanceOf(address(kakaroto)) >= meInitialBalance + amount);
-        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
     }
 
     function test_increaseDebt() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -479,13 +479,13 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = fiat.balanceOf(me);
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
 
-        _modifyCollateralAndDebt(address(vaultFY_USDC06), fyUSDC06, address(0), me, 0, toInt256(500 * WAD));
+        _modifyCollateralAndDebt(address(vaultFY_USDC06), fyUSDC04, address(0), me, 0, toInt256(500 * WAD));
 
         assertEq(fiat.balanceOf(me), meInitialBalance + (500 * WAD));
         assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt + (500 * WAD));
@@ -493,7 +493,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_increaseDebt_send_to_user() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -501,7 +501,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(0),
             testAmount,
             0,
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 kakarotoInitialBalance = fiat.balanceOf(address(kakaroto));
@@ -509,7 +509,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
         _modifyCollateralAndDebt(
             address(vaultFY_USDC06),
-            fyUSDC06,
+            fyUSDC04,
             address(0),
             address(kakaroto),
             0,
@@ -522,7 +522,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_decreaseDebt() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -530,13 +530,13 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = fiat.balanceOf(me);
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
 
-        _modifyCollateralAndDebt(address(vaultFY_USDC06), fyUSDC06, address(0), me, 0, -toInt256(200 * WAD));
+        _modifyCollateralAndDebt(address(vaultFY_USDC06), fyUSDC04, address(0), me, 0, -toInt256(200 * WAD));
 
         assertEq(fiat.balanceOf(me), meInitialBalance - (200 * WAD));
         assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (200 * WAD));
@@ -544,7 +544,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_decreaseDebt_get_fiat_from_user() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -552,7 +552,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         fiat.transfer(address(kakaroto), 500 * WAD);
@@ -562,7 +562,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
         _modifyCollateralAndDebt(
             address(vaultFY_USDC06),
-            fyUSDC06,
+            fyUSDC04,
             address(0),
             address(kakaroto),
             0,
@@ -575,7 +575,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_decreaseDebt_get_fiat_from_proxy_zero() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -583,7 +583,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         fiat.transfer(address(userProxy), 500 * WAD);
@@ -591,7 +591,7 @@ contract VaultFYActions_RPC_tests is DSTest {
         uint256 userProxyInitialBalance = fiat.balanceOf(address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
 
-        _modifyCollateralAndDebt(address(vaultFY_USDC06), fyUSDC06, address(0), address(0), 0, -toInt256(200 * WAD));
+        _modifyCollateralAndDebt(address(vaultFY_USDC06), fyUSDC04, address(0), address(0), 0, -toInt256(200 * WAD));
 
         assertEq(fiat.balanceOf(address(userProxy)), userProxyInitialBalance - (200 * WAD));
         assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (200 * WAD));
@@ -599,7 +599,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_decreaseDebt_get_fiat_from_proxy_address() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -607,7 +607,7 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         fiat.transfer(address(userProxy), 500 * WAD);
@@ -617,7 +617,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
         _modifyCollateralAndDebt(
             address(vaultFY_USDC06),
-            fyUSDC06,
+            fyUSDC04,
             address(0),
             address(userProxy),
             0,
@@ -630,14 +630,14 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_increaseCollateral_from_underlier_and_increaseDebt() public {
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
         uint256 fiatMeInitialBalance = fiat.balanceOf(me);
 
         uint256 tokenAmount = 1000 * ONE_USDC;
         uint256 debtAmount = 500 * WAD;
-        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -645,14 +645,14 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         assertEq(underlierUSDC.balanceOf(me), meInitialBalance - tokenAmount);
-        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
         assertTrue(
             _collateral(address(vaultFY_USDC06), address(userProxy)) >=
-                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC04).decimals())
         );
 
         assertEq(fiat.balanceOf(me), fiatMeInitialBalance + debtAmount);
@@ -663,14 +663,14 @@ contract VaultFYActions_RPC_tests is DSTest {
         underlierUSDC.transfer(address(kakaroto), 1000 * ONE_USDC);
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
         uint256 fiatMeInitialBalance = fiat.balanceOf(me);
 
         uint256 tokenAmount = 1000 * ONE_USDC;
         uint256 debtAmount = 500 * WAD;
-        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -678,14 +678,14 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         assertEq(underlierUSDC.balanceOf(address(kakaroto)), meInitialBalance - tokenAmount);
-        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
         assertTrue(
             _collateral(address(vaultFY_USDC06), address(userProxy)) >=
-                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC04).decimals())
         );
 
         assertEq(fiat.balanceOf(me), fiatMeInitialBalance + debtAmount);
@@ -696,14 +696,14 @@ contract VaultFYActions_RPC_tests is DSTest {
         underlierUSDC.transfer(address(userProxy), 1000 * ONE_USDC);
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(address(userProxy));
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
         uint256 fiatMeInitialBalance = fiat.balanceOf(me);
 
         uint256 tokenAmount = 1000 * ONE_USDC;
         uint256 debtAmount = 500 * WAD;
-        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -711,14 +711,14 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, previewOut)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(address(userProxy)), meInitialBalance - tokenAmount);
-        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
         assertTrue(
             _collateral(address(vaultFY_USDC06), address(userProxy)) >=
-                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC04).decimals())
         );
 
         assertEq(fiat.balanceOf(me), fiatMeInitialBalance + debtAmount);
@@ -729,14 +729,14 @@ contract VaultFYActions_RPC_tests is DSTest {
         underlierUSDC.transfer(address(userProxy), 1000 * ONE_USDC);
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(address(userProxy));
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
         uint256 fiatMeInitialBalance = fiat.balanceOf(me);
 
         uint256 tokenAmount = 1000 * ONE_USDC;
         uint256 debtAmount = 500 * WAD;
-        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -744,14 +744,14 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, previewOut)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, previewOut)
         );
 
         assertEq(underlierUSDC.balanceOf(address(userProxy)), meInitialBalance - tokenAmount);
-        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
         assertTrue(
             _collateral(address(vaultFY_USDC06), address(userProxy)) >=
-                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC04).decimals())
         );
 
         assertEq(fiat.balanceOf(me), fiatMeInitialBalance + debtAmount);
@@ -760,14 +760,14 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_increaseCollateral_from_underlier_and_increaseDebt_send_fiat_to_user() public {
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
         uint256 fiatMeInitialBalance = fiat.balanceOf(address(kakaroto));
 
         uint256 tokenAmount = 1000 * ONE_USDC;
         uint256 debtAmount = 500 * WAD;
-        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -775,14 +775,14 @@ contract VaultFYActions_RPC_tests is DSTest {
             address(kakaroto),
             tokenAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         assertEq(underlierUSDC.balanceOf(me), meInitialBalance - tokenAmount);
-        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
         assertTrue(
             _collateral(address(vaultFY_USDC06), address(userProxy)) >=
-                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC04).decimals())
         );
 
         assertEq(fiat.balanceOf(address(kakaroto)), fiatMeInitialBalance + debtAmount);
@@ -791,7 +791,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_decrease_debt_and_decrease_collateral_get_underlier() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -799,20 +799,20 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
         uint256 fiatMeInitialBalance = fiat.balanceOf(me);
 
         uint256 amount = 300 * ONE_USDC;
-        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC04LP);
 
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
-            fyUSDC06,
+            fyUSDC04,
             address(underlierUSDC),
             expectedDelta / 2,
             expectedDelta
@@ -821,8 +821,8 @@ contract VaultFYActions_RPC_tests is DSTest {
         _sellCollateralAndModifyDebt(address(vaultFY_USDC06), me, me, amount, -toInt256(100 * WAD), swapParams);
 
         assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + swapParams.minAssetOut);
-        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
 
         assertEq(fiat.balanceOf(me), fiatMeInitialBalance - (100 * WAD));
@@ -831,7 +831,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_decrease_debt_and_decrease_collateral_get_underlier_to_user() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -839,20 +839,20 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
         uint256 fiatMeInitialBalance = fiat.balanceOf(me);
 
         uint256 amount = 300 * ONE_USDC;
-        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC04LP);
 
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
-            fyUSDC06,
+            fyUSDC04,
             address(underlierUSDC),
             expectedDelta / 2,
             expectedDelta
@@ -868,8 +868,8 @@ contract VaultFYActions_RPC_tests is DSTest {
         );
 
         assertTrue(underlierUSDC.balanceOf(address(kakaroto)) >= meInitialBalance + swapParams.minAssetOut);
-        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
 
         assertEq(fiat.balanceOf(me), fiatMeInitialBalance - (100 * WAD));
@@ -878,7 +878,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_decrease_debt_get_fiat_from_user_and_decrease_collateral_get_underlier() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -886,11 +886,11 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
 
@@ -898,10 +898,10 @@ contract VaultFYActions_RPC_tests is DSTest {
         uint256 fiatKakarotoInitialBalance = fiat.balanceOf(address(kakaroto));
 
         uint256 amount = 300 * ONE_USDC;
-        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC04LP);
 
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
-            fyUSDC06,
+            fyUSDC04,
             address(underlierUSDC),
             expectedDelta / 2,
             expectedDelta
@@ -917,8 +917,8 @@ contract VaultFYActions_RPC_tests is DSTest {
         );
 
         assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + swapParams.minAssetOut);
-        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
 
         assertEq(fiat.balanceOf(address(kakaroto)), fiatKakarotoInitialBalance - (100 * WAD));
@@ -927,7 +927,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_decrease_debt_get_fiat_from_proxy_zero_and_decrease_collateral_get_underlier() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -935,11 +935,11 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
 
@@ -947,10 +947,10 @@ contract VaultFYActions_RPC_tests is DSTest {
         uint256 fiatProxyInitialBalance = fiat.balanceOf(address(userProxy));
 
         uint256 amount = 300 * ONE_USDC;
-        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC04LP);
 
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
-            fyUSDC06,
+            fyUSDC04,
             address(underlierUSDC),
             expectedDelta / 2,
             expectedDelta
@@ -959,8 +959,8 @@ contract VaultFYActions_RPC_tests is DSTest {
         _sellCollateralAndModifyDebt(address(vaultFY_USDC06), me, address(0), amount, -toInt256(100 * WAD), swapParams);
 
         assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + swapParams.minAssetOut);
-        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
 
         assertEq(fiat.balanceOf(address(userProxy)), fiatProxyInitialBalance - (100 * WAD));
@@ -969,7 +969,7 @@ contract VaultFYActions_RPC_tests is DSTest {
 
     function test_decrease_debt_get_fiat_from_proxy_and_decrease_collateral_get_underlier() public {
         uint256 testAmount = 1000 * ONE_USDC;
-        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC04LP);
 
         _buyCollateralAndModifyDebt(
             address(vaultFY_USDC06),
@@ -977,11 +977,11 @@ contract VaultFYActions_RPC_tests is DSTest {
             me,
             testAmount,
             toInt256(500 * WAD),
-            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+            _getSwapParams(address(underlierUSDC), fyUSDC04, previewOut, 0)
         );
 
         uint256 meInitialBalance = underlierUSDC.balanceOf(me);
-        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 vaultInitialBalance = IERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06));
         uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
         uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
 
@@ -989,10 +989,10 @@ contract VaultFYActions_RPC_tests is DSTest {
         uint256 fiatProxyInitialBalance = fiat.balanceOf(address(userProxy));
 
         uint256 amount = 300 * ONE_USDC;
-        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC04LP);
 
         VaultFYActions.SwapParams memory swapParams = _getSwapParams(
-            fyUSDC06,
+            fyUSDC04,
             address(underlierUSDC),
             expectedDelta / 2,
             expectedDelta
@@ -1008,8 +1008,8 @@ contract VaultFYActions_RPC_tests is DSTest {
         );
 
         assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + swapParams.minAssetOut);
-        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
-        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(ERC20(fyUSDC04).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC04).decimals());
         assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
 
         assertEq(fiat.balanceOf(address(userProxy)), fiatProxyInitialBalance - (100 * WAD));

--- a/src/test/rpc/VaultFYActions.t.sol
+++ b/src/test/rpc/VaultFYActions.t.sol
@@ -18,7 +18,7 @@ import {toInt256, WAD, wdiv} from "fiat/utils/Math.sol";
 import {PRBProxyFactory} from "proxy/contracts/PRBProxyFactory.sol";
 import {PRBProxy} from "proxy/contracts/PRBProxy.sol";
 
-import {VaultFY} from "../../../../vaults/src/VaultFY.sol"; // todo replace path when fy vault pr is merged
+import {VaultFY} from "vaults/VaultFY.sol";
 import {VaultFactory} from "vaults/VaultFactory.sol";
 
 import {Hevm} from "../utils/Hevm.sol";

--- a/src/test/rpc/VaultFYActions.t.sol
+++ b/src/test/rpc/VaultFYActions.t.sol
@@ -1,0 +1,1018 @@
+pragma solidity ^0.8.4;
+
+import {DSTest} from "ds-test/test.sol";
+
+import {ERC20} from "openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import {MockProvider} from "mockprovider/MockProvider.sol";
+
+import {Codex} from "fiat/Codex.sol";
+import {Collybus} from "fiat/Collybus.sol";
+import {Publican} from "fiat/Publican.sol";
+import {FIAT} from "fiat/FIAT.sol";
+import {Moneta} from "fiat/Moneta.sol";
+import {toInt256, WAD, wdiv} from "fiat/utils/Math.sol";
+
+import {PRBProxyFactory} from "proxy/contracts/PRBProxyFactory.sol";
+import {PRBProxy} from "proxy/contracts/PRBProxy.sol";
+
+import {VaultFY} from "../../../../vaults/src/VaultFY.sol"; // todo replace path when fy vault pr is merged
+import {VaultFactory} from "vaults/VaultFactory.sol";
+
+import {Hevm} from "../utils/Hevm.sol";
+import {Caller} from "../utils/Caller.sol";
+
+import {VaultFYActions, IFYPool} from "../../vault/VaultFYActions.sol";
+
+import {console} from "../utils/Console.sol";
+
+contract VaultFYActions_RPC_tests is DSTest {
+    Hevm internal hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    IERC20 internal underlierUSDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48); // USDC
+    PRBProxyFactory internal prbProxyFactory;
+    address internal fyUSDC06 = address(0x4568bBcf929AB6B4d716F2a3D5A967a1908B4F1C);
+    address internal fyUSDC06LP = address(0xEf82611C6120185D3BF6e020D1993B49471E7da0);
+
+    Codex internal codex;
+    Publican internal publican;
+    MockProvider internal collybus;
+    Moneta internal moneta;
+    FIAT internal fiat;
+    VaultFYActions internal vaultActions;
+    PRBProxy internal userProxy;
+
+    VaultFY internal vaultFY_impl;
+    VaultFY internal vaultFY_USDC06;
+    VaultFactory vaultFactory;
+    address internal me = address(this);
+    Caller kakaroto;
+    uint256 ONE_USDC = 1e6;
+
+    function _mintUSDC(address to, uint256 amount) internal {
+        // USDC minters
+        hevm.store(address(underlierUSDC), keccak256(abi.encode(address(this), uint256(12))), bytes32(uint256(1)));
+        // USDC minterAllowed
+        hevm.store(
+            address(underlierUSDC),
+            keccak256(abi.encode(address(this), uint256(13))),
+            bytes32(uint256(type(uint256).max))
+        );
+        string memory sig = "mint(address,uint256)";
+        (bool ok, ) = address(underlierUSDC).call(abi.encodeWithSignature(sig, to, amount));
+        assert(ok);
+    }
+
+    function _collateral(address vault, address user) internal view returns (uint256) {
+        (uint256 collateral, ) = codex.positions(vault, 0, user);
+        return collateral;
+    }
+
+    function _normalDebt(address vault, address user) internal view returns (uint256) {
+        (, uint256 normalDebt) = codex.positions(vault, 0, user);
+        return normalDebt;
+    }
+
+    function _modifyCollateralAndDebt(
+        address vault,
+        address token,
+        address collateralizer,
+        address creditor,
+        int256 deltaCollateral,
+        int256 deltaNormalDebt
+    ) internal {
+        userProxy.execute(
+            address(vaultActions),
+            abi.encodeWithSelector(
+                vaultActions.modifyCollateralAndDebt.selector,
+                vault,
+                token,
+                0,
+                address(userProxy),
+                collateralizer,
+                creditor,
+                deltaCollateral,
+                deltaNormalDebt
+            )
+        );
+    }
+
+    function _buyCollateralAndModifyDebt(
+        address vault,
+        address collateralizer,
+        address creditor,
+        uint256 underlierAmount,
+        int256 deltaNormalDebt,
+        VaultFYActions.SwapParams memory swapParams
+    ) internal {
+        userProxy.execute(
+            address(vaultActions),
+            abi.encodeWithSelector(
+                vaultActions.buyCollateralAndModifyDebt.selector,
+                vault,
+                address(userProxy),
+                collateralizer,
+                creditor,
+                underlierAmount,
+                deltaNormalDebt,
+                swapParams
+            )
+        );
+    }
+
+    function _sellCollateralAndModifyDebt(
+        address vault,
+        address collateralizer,
+        address creditor,
+        uint256 pTokenAmount,
+        int256 deltaNormalDebt,
+        VaultFYActions.SwapParams memory swapParams
+    ) internal {
+        userProxy.execute(
+            address(vaultActions),
+            abi.encodeWithSelector(
+                vaultActions.sellCollateralAndModifyDebt.selector,
+                vault,
+                address(userProxy),
+                collateralizer,
+                creditor,
+                pTokenAmount,
+                deltaNormalDebt,
+                swapParams
+            )
+        );
+    }
+
+    function _redeemCollateralAndModifyDebt(
+        address vault,
+        address collateralizer,
+        address creditor,
+        uint256 pTokenAmount,
+        int256 deltaNormalDebt
+    ) internal {
+        userProxy.execute(
+            address(vaultActions),
+            abi.encodeWithSelector(
+                vaultActions.redeemCollateralAndModifyDebt.selector,
+                vault,
+                VaultFY(vault).token(),
+                address(userProxy),
+                collateralizer,
+                creditor,
+                pTokenAmount,
+                deltaNormalDebt
+            )
+        );
+    }
+
+    function _getSwapParams(
+        address assetIn,
+        address assetOut,
+        uint256 minOutput,
+        uint256 approveAmount
+    ) internal view returns (VaultFYActions.SwapParams memory swapParams) {
+        swapParams.yieldSpacePool = fyUSDC06LP;
+        swapParams.assetIn = assetIn;
+        swapParams.assetOut = assetOut;
+        swapParams.minAssetOut = minOutput;
+        swapParams.approve = approveAmount;
+    }
+
+    function setUp() public {
+        kakaroto = new Caller();
+        vaultFactory = new VaultFactory();
+        codex = new Codex();
+        publican = new Publican(address(codex));
+        collybus = new MockProvider();
+        fiat = new FIAT();
+        moneta = new Moneta(address(codex), address(fiat));
+        fiat.allowCaller(fiat.mint.selector, address(moneta));
+        vaultActions = new VaultFYActions(address(codex), address(moneta), address(fiat), address(publican));
+
+        prbProxyFactory = new PRBProxyFactory();
+        userProxy = PRBProxy(prbProxyFactory.deployFor(me));
+
+        vaultFY_impl = new VaultFY(address(codex), address(underlierUSDC));
+
+        codex.setParam("globalDebtCeiling", uint256(1000 ether));
+        codex.allowCaller(keccak256("ANY_SIG"), address(publican));
+
+        codex.setParam("globalDebtCeiling", uint256(1000 ether));
+        codex.allowCaller(keccak256("ANY_SIG"), address(publican));
+
+        _mintUSDC(me, 2000000 * ONE_USDC);
+
+        address instance = vaultFactory.createVault(address(vaultFY_impl), abi.encode(fyUSDC06, address(collybus)));
+
+        vaultFY_USDC06 = VaultFY(instance);
+        codex.setParam(instance, "debtCeiling", uint256(1000 ether));
+        codex.allowCaller(codex.modifyBalance.selector, instance);
+        codex.init(instance);
+
+        publican.init(instance);
+        publican.setParam(instance, "interestPerSecond", WAD);
+
+        // Token approvals
+        // USDC
+        underlierUSDC.approve(address(userProxy), type(uint256).max);
+        kakaroto.externalCall(
+            address(underlierUSDC),
+            abi.encodeWithSelector(underlierUSDC.approve.selector, address(userProxy), type(uint256).max)
+        );
+        // Collateral
+        IERC20(fyUSDC06).approve(address(userProxy), type(uint256).max);
+        // FIAT
+        fiat.approve(address(userProxy), type(uint256).max);
+        kakaroto.externalCall(
+            address(fiat),
+            abi.encodeWithSelector(fiat.approve.selector, address(userProxy), type(uint256).max)
+        );
+        userProxy.execute(
+            address(vaultActions),
+            abi.encodeWithSelector(vaultActions.approveFIAT.selector, address(moneta), type(uint256).max)
+        );
+
+        // Mock responses
+        collybus.givenSelectorReturnResponse(
+            Collybus.read.selector,
+            MockProvider.ReturnData({success: true, data: abi.encode(uint256(WAD))}),
+            false
+        );
+    }
+
+    function test_increaseCollateral_from_underlier() public {
+        uint128 amount = 100 * uint128(ONE_USDC);
+        uint256 meInitialBalance = underlierUSDC.balanceOf(me);
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(0),
+            amount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        assertEq(underlierUSDC.balanceOf(me), meInitialBalance - amount);
+        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= previewOut + vaultInitialBalance);
+        assertTrue(
+            _collateral(address(vaultFY_USDC06), address(userProxy)) >=
+                initialCollateral + wdiv(previewOut, 10**IERC20Metadata(fyUSDC06).decimals())
+        );
+    }
+
+    function test_increaseCollateral_from_user_underlier() public {
+        uint256 amount = 100 * ONE_USDC;
+        underlierUSDC.transfer(address(kakaroto), amount);
+
+        uint256 kakarotoInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            address(kakaroto),
+            address(0),
+            amount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        assertEq(underlierUSDC.balanceOf(address(kakaroto)), kakarotoInitialBalance - amount);
+        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + previewOut);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertTrue(_collateral(address(vaultFY_USDC06), address(userProxy)) >= initialCollateral + wadAmount);
+    }
+
+    function test_increaseCollateral_from_proxy_zero_underlier() public {
+        uint256 amount = 100 * ONE_USDC;
+        underlierUSDC.transfer(address(userProxy), amount);
+        uint256 userProxyInitialBalance = underlierUSDC.balanceOf(address(userProxy));
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            address(0),
+            address(0),
+            amount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, amount)
+        );
+
+        assertEq(underlierUSDC.balanceOf(address(userProxy)), userProxyInitialBalance - amount);
+        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertTrue(_collateral(address(vaultFY_USDC06), address(userProxy)) >= initialCollateral + wadAmount);
+    }
+
+    function test_increaseCollateral_from_proxy_address_underlier() public {
+        uint256 amount = 100 * ONE_USDC;
+        underlierUSDC.transfer(address(userProxy), amount);
+        uint256 userProxyInitialBalance = underlierUSDC.balanceOf(address(userProxy));
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 previewOut = vaultActions.underlierToFYToken(amount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            address(userProxy),
+            address(0),
+            amount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, amount)
+        );
+
+        assertEq(underlierUSDC.balanceOf(address(userProxy)), userProxyInitialBalance - amount);
+        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertTrue(_collateral(address(vaultFY_USDC06), address(userProxy)) >= initialCollateral + wadAmount);
+    }
+
+    function test_decreaseCollateral_get_underlier() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(0),
+            testAmount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(me);
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+
+        uint256 amount = 500 * ONE_USDC;
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+
+        VaultFYActions.SwapParams memory swapParams = _getSwapParams(
+            fyUSDC06,
+            address(underlierUSDC),
+            expectedDelta,
+            0
+        );
+
+        _sellCollateralAndModifyDebt(address(vaultFY_USDC06), me, address(0), amount, 0, swapParams);
+
+        emit log_named_uint("meInitialBalance", meInitialBalance);
+        emit log_named_uint("expectedDelta", expectedDelta);
+        emit log_named_uint("balance", underlierUSDC.balanceOf(me));
+
+        assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + expectedDelta);
+        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
+    }
+
+    function test_decreaseCollateral_send_underlier_to_user() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(0),
+            testAmount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 kakarotoInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+
+        uint256 amount = 500 * ONE_USDC;
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+
+        VaultFYActions.SwapParams memory swapParams = _getSwapParams(
+            fyUSDC06,
+            address(underlierUSDC),
+            expectedDelta,
+            0
+        );
+
+        _sellCollateralAndModifyDebt(address(vaultFY_USDC06), address(kakaroto), address(0), amount, 0, swapParams);
+
+        assertTrue(underlierUSDC.balanceOf(address(kakaroto)) >= kakarotoInitialBalance + expectedDelta);
+        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
+    }
+
+    function test_decreaseCollateral_redeem_underlier() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(0),
+            testAmount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(me);
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+
+        uint256 amount = 500 * ONE_USDC;
+
+        hevm.roll(block.number + ((vaultFY_USDC06.maturity(0) - block.timestamp) / 12));
+        hevm.warp(vaultFY_USDC06.maturity(0));
+
+        _redeemCollateralAndModifyDebt(address(vaultFY_USDC06), me, address(0), amount, 0);
+
+        assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + amount);
+        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
+    }
+
+    function test_decreaseCollateral_redeem_underlier_to_user() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(0),
+            testAmount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+
+        uint256 amount = 500 * ONE_USDC;
+
+        hevm.roll(block.number + ((vaultFY_USDC06.maturity(0) - block.timestamp) / 12));
+        hevm.warp(vaultFY_USDC06.maturity(0));
+
+        _redeemCollateralAndModifyDebt(address(vaultFY_USDC06), address(kakaroto), address(0), amount, 0);
+
+        assertTrue(underlierUSDC.balanceOf(address(kakaroto)) >= meInitialBalance + amount);
+        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
+    }
+
+    function test_increaseDebt() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(0),
+            testAmount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = fiat.balanceOf(me);
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+
+        _modifyCollateralAndDebt(address(vaultFY_USDC06), fyUSDC06, address(0), me, 0, toInt256(500 * WAD));
+
+        assertEq(fiat.balanceOf(me), meInitialBalance + (500 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt + (500 * WAD));
+    }
+
+    function test_increaseDebt_send_to_user() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(0),
+            testAmount,
+            0,
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 kakarotoInitialBalance = fiat.balanceOf(address(kakaroto));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+
+        _modifyCollateralAndDebt(
+            address(vaultFY_USDC06),
+            fyUSDC06,
+            address(0),
+            address(kakaroto),
+            0,
+            toInt256(500 * WAD)
+        );
+
+        assertEq(fiat.balanceOf(address(kakaroto)), kakarotoInitialBalance + (500 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt + (500 * WAD));
+    }
+
+    function test_decreaseDebt() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            testAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = fiat.balanceOf(me);
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+
+        _modifyCollateralAndDebt(address(vaultFY_USDC06), fyUSDC06, address(0), me, 0, -toInt256(200 * WAD));
+
+        assertEq(fiat.balanceOf(me), meInitialBalance - (200 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (200 * WAD));
+    }
+
+    function test_decreaseDebt_get_fiat_from_user() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            testAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        fiat.transfer(address(kakaroto), 500 * WAD);
+
+        uint256 kakarotoInitialBalance = fiat.balanceOf(address(kakaroto));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+
+        _modifyCollateralAndDebt(
+            address(vaultFY_USDC06),
+            fyUSDC06,
+            address(0),
+            address(kakaroto),
+            0,
+            -toInt256(200 * WAD)
+        );
+
+        assertEq(fiat.balanceOf(address(kakaroto)), kakarotoInitialBalance - (200 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (200 * WAD));
+    }
+
+    function test_decreaseDebt_get_fiat_from_proxy_zero() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            testAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        fiat.transfer(address(userProxy), 500 * WAD);
+
+        uint256 userProxyInitialBalance = fiat.balanceOf(address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+
+        _modifyCollateralAndDebt(address(vaultFY_USDC06), fyUSDC06, address(0), address(0), 0, -toInt256(200 * WAD));
+
+        assertEq(fiat.balanceOf(address(userProxy)), userProxyInitialBalance - (200 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (200 * WAD));
+    }
+
+    function test_decreaseDebt_get_fiat_from_proxy_address() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            testAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        fiat.transfer(address(userProxy), 500 * WAD);
+
+        uint256 userProxyInitialBalance = fiat.balanceOf(address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+
+        _modifyCollateralAndDebt(
+            address(vaultFY_USDC06),
+            fyUSDC06,
+            address(0),
+            address(userProxy),
+            0,
+            -toInt256(200 * WAD)
+        );
+
+        assertEq(fiat.balanceOf(address(userProxy)), userProxyInitialBalance - (200 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (200 * WAD));
+    }
+
+    function test_increaseCollateral_from_underlier_and_increaseDebt() public {
+        uint256 meInitialBalance = underlierUSDC.balanceOf(me);
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+        uint256 fiatMeInitialBalance = fiat.balanceOf(me);
+
+        uint256 tokenAmount = 1000 * ONE_USDC;
+        uint256 debtAmount = 500 * WAD;
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            tokenAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        assertEq(underlierUSDC.balanceOf(me), meInitialBalance - tokenAmount);
+        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(
+            _collateral(address(vaultFY_USDC06), address(userProxy)) >=
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+        );
+
+        assertEq(fiat.balanceOf(me), fiatMeInitialBalance + debtAmount);
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt + debtAmount);
+    }
+
+    function test_increaseCollateral_from_user_underlier_and_increaseDebt() public {
+        underlierUSDC.transfer(address(kakaroto), 1000 * ONE_USDC);
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+        uint256 fiatMeInitialBalance = fiat.balanceOf(me);
+
+        uint256 tokenAmount = 1000 * ONE_USDC;
+        uint256 debtAmount = 500 * WAD;
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            address(kakaroto),
+            me,
+            tokenAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        assertEq(underlierUSDC.balanceOf(address(kakaroto)), meInitialBalance - tokenAmount);
+        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(
+            _collateral(address(vaultFY_USDC06), address(userProxy)) >=
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+        );
+
+        assertEq(fiat.balanceOf(me), fiatMeInitialBalance + debtAmount);
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt + debtAmount);
+    }
+
+    function test_increaseCollateral_from_zeroAddress_proxy_underlier_and_increaseDebt() public {
+        underlierUSDC.transfer(address(userProxy), 1000 * ONE_USDC);
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(address(userProxy));
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+        uint256 fiatMeInitialBalance = fiat.balanceOf(me);
+
+        uint256 tokenAmount = 1000 * ONE_USDC;
+        uint256 debtAmount = 500 * WAD;
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            address(0),
+            me,
+            tokenAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, previewOut)
+        );
+
+        assertEq(underlierUSDC.balanceOf(address(userProxy)), meInitialBalance - tokenAmount);
+        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(
+            _collateral(address(vaultFY_USDC06), address(userProxy)) >=
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+        );
+
+        assertEq(fiat.balanceOf(me), fiatMeInitialBalance + debtAmount);
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt + debtAmount);
+    }
+
+    function test_increaseCollateral_from_proxy_underlier_and_increaseDebt() public {
+        underlierUSDC.transfer(address(userProxy), 1000 * ONE_USDC);
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(address(userProxy));
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+        uint256 fiatMeInitialBalance = fiat.balanceOf(me);
+
+        uint256 tokenAmount = 1000 * ONE_USDC;
+        uint256 debtAmount = 500 * WAD;
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            address(userProxy),
+            me,
+            tokenAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, previewOut)
+        );
+
+        assertEq(underlierUSDC.balanceOf(address(userProxy)), meInitialBalance - tokenAmount);
+        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(
+            _collateral(address(vaultFY_USDC06), address(userProxy)) >=
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+        );
+
+        assertEq(fiat.balanceOf(me), fiatMeInitialBalance + debtAmount);
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt + debtAmount);
+    }
+
+    function test_increaseCollateral_from_underlier_and_increaseDebt_send_fiat_to_user() public {
+        uint256 meInitialBalance = underlierUSDC.balanceOf(me);
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+        uint256 fiatMeInitialBalance = fiat.balanceOf(address(kakaroto));
+
+        uint256 tokenAmount = 1000 * ONE_USDC;
+        uint256 debtAmount = 500 * WAD;
+        uint256 previewOut = vaultActions.underlierToFYToken(tokenAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(kakaroto),
+            tokenAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        assertEq(underlierUSDC.balanceOf(me), meInitialBalance - tokenAmount);
+        assertTrue(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)) >= vaultInitialBalance + tokenAmount);
+        assertTrue(
+            _collateral(address(vaultFY_USDC06), address(userProxy)) >=
+                initialCollateral + wdiv(tokenAmount, 10**IERC20Metadata(fyUSDC06).decimals())
+        );
+
+        assertEq(fiat.balanceOf(address(kakaroto)), fiatMeInitialBalance + debtAmount);
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt + debtAmount);
+    }
+
+    function test_decrease_debt_and_decrease_collateral_get_underlier() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            testAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(me);
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+        uint256 fiatMeInitialBalance = fiat.balanceOf(me);
+
+        uint256 amount = 300 * ONE_USDC;
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+
+        VaultFYActions.SwapParams memory swapParams = _getSwapParams(
+            fyUSDC06,
+            address(underlierUSDC),
+            expectedDelta / 2,
+            expectedDelta
+        );
+
+        _sellCollateralAndModifyDebt(address(vaultFY_USDC06), me, me, amount, -toInt256(100 * WAD), swapParams);
+
+        assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + swapParams.minAssetOut);
+        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
+
+        assertEq(fiat.balanceOf(me), fiatMeInitialBalance - (100 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (100 * WAD));
+    }
+
+    function test_decrease_debt_and_decrease_collateral_get_underlier_to_user() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            testAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(address(kakaroto));
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+        uint256 fiatMeInitialBalance = fiat.balanceOf(me);
+
+        uint256 amount = 300 * ONE_USDC;
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+
+        VaultFYActions.SwapParams memory swapParams = _getSwapParams(
+            fyUSDC06,
+            address(underlierUSDC),
+            expectedDelta / 2,
+            expectedDelta
+        );
+
+        _sellCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            address(kakaroto),
+            me,
+            amount,
+            -toInt256(100 * WAD),
+            swapParams
+        );
+
+        assertTrue(underlierUSDC.balanceOf(address(kakaroto)) >= meInitialBalance + swapParams.minAssetOut);
+        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
+
+        assertEq(fiat.balanceOf(me), fiatMeInitialBalance - (100 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (100 * WAD));
+    }
+
+    function test_decrease_debt_get_fiat_from_user_and_decrease_collateral_get_underlier() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            testAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(me);
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+
+        fiat.transfer(address(kakaroto), 500 * WAD);
+        uint256 fiatKakarotoInitialBalance = fiat.balanceOf(address(kakaroto));
+
+        uint256 amount = 300 * ONE_USDC;
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+
+        VaultFYActions.SwapParams memory swapParams = _getSwapParams(
+            fyUSDC06,
+            address(underlierUSDC),
+            expectedDelta / 2,
+            expectedDelta
+        );
+
+        _sellCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(kakaroto),
+            amount,
+            -toInt256(100 * WAD),
+            swapParams
+        );
+
+        assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + swapParams.minAssetOut);
+        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
+
+        assertEq(fiat.balanceOf(address(kakaroto)), fiatKakarotoInitialBalance - (100 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (100 * WAD));
+    }
+
+    function test_decrease_debt_get_fiat_from_proxy_zero_and_decrease_collateral_get_underlier() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            testAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(me);
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+
+        fiat.transfer(address(userProxy), 500 * WAD);
+        uint256 fiatProxyInitialBalance = fiat.balanceOf(address(userProxy));
+
+        uint256 amount = 300 * ONE_USDC;
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+
+        VaultFYActions.SwapParams memory swapParams = _getSwapParams(
+            fyUSDC06,
+            address(underlierUSDC),
+            expectedDelta / 2,
+            expectedDelta
+        );
+
+        _sellCollateralAndModifyDebt(address(vaultFY_USDC06), me, address(0), amount, -toInt256(100 * WAD), swapParams);
+
+        assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + swapParams.minAssetOut);
+        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
+
+        assertEq(fiat.balanceOf(address(userProxy)), fiatProxyInitialBalance - (100 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (100 * WAD));
+    }
+
+    function test_decrease_debt_get_fiat_from_proxy_and_decrease_collateral_get_underlier() public {
+        uint256 testAmount = 1000 * ONE_USDC;
+        uint256 previewOut = vaultActions.underlierToFYToken(testAmount, fyUSDC06LP);
+
+        _buyCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            me,
+            testAmount,
+            toInt256(500 * WAD),
+            _getSwapParams(address(underlierUSDC), fyUSDC06, previewOut, 0)
+        );
+
+        uint256 meInitialBalance = underlierUSDC.balanceOf(me);
+        uint256 vaultInitialBalance = IERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06));
+        uint256 initialCollateral = _collateral(address(vaultFY_USDC06), address(userProxy));
+        uint256 initialDebt = _normalDebt(address(vaultFY_USDC06), address(userProxy));
+
+        fiat.transfer(address(userProxy), 500 * WAD);
+        uint256 fiatProxyInitialBalance = fiat.balanceOf(address(userProxy));
+
+        uint256 amount = 300 * ONE_USDC;
+        uint256 expectedDelta = vaultActions.fyTokenToUnderlier(amount, fyUSDC06LP);
+
+        VaultFYActions.SwapParams memory swapParams = _getSwapParams(
+            fyUSDC06,
+            address(underlierUSDC),
+            expectedDelta / 2,
+            expectedDelta
+        );
+
+        _sellCollateralAndModifyDebt(
+            address(vaultFY_USDC06),
+            me,
+            address(userProxy),
+            amount,
+            -toInt256(100 * WAD),
+            swapParams
+        );
+
+        assertTrue(underlierUSDC.balanceOf(me) >= meInitialBalance + swapParams.minAssetOut);
+        assertEq(ERC20(fyUSDC06).balanceOf(address(vaultFY_USDC06)), vaultInitialBalance - amount);
+        uint256 wadAmount = wdiv(amount, 10**IERC20Metadata(fyUSDC06).decimals());
+        assertEq(_collateral(address(vaultFY_USDC06), address(userProxy)), initialCollateral - wadAmount);
+
+        assertEq(fiat.balanceOf(address(userProxy)), fiatProxyInitialBalance - (100 * WAD));
+        assertEq(_normalDebt(address(vaultFY_USDC06), address(userProxy)), initialDebt - (100 * WAD));
+    }
+}

--- a/src/test/rpc/VaultFYActions.t.sol
+++ b/src/test/rpc/VaultFYActions.t.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.4;
 
 import {DSTest} from "ds-test/test.sol";

--- a/src/test/utils/Console.sol
+++ b/src/test/utils/Console.sol
@@ -1,0 +1,3067 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
+
+library console {
+    address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);
+
+    function _sendLogPayload(bytes memory payload) private view {
+        uint256 payloadLength = payload.length;
+        address consoleAddress = CONSOLE_ADDRESS;
+        assembly {
+            let payloadStart := add(payload, 32)
+            let r := staticcall(gas(), consoleAddress, payloadStart, payloadLength, 0, 0)
+        }
+    }
+
+    function log() internal view {
+        _sendLogPayload(abi.encodeWithSignature("log()"));
+    }
+
+    function logInt(int256 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(int)", p0));
+    }
+
+    function logUint(uint256 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+    }
+
+    function logString(string memory p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+    }
+
+    function logBool(bool p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+    }
+
+    function logAddress(address p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+    }
+
+    function logBytes(bytes memory p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes)", p0));
+    }
+
+    function logBytes1(bytes1 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes1)", p0));
+    }
+
+    function logBytes2(bytes2 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes2)", p0));
+    }
+
+    function logBytes3(bytes3 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes3)", p0));
+    }
+
+    function logBytes4(bytes4 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes4)", p0));
+    }
+
+    function logBytes5(bytes5 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes5)", p0));
+    }
+
+    function logBytes6(bytes6 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes6)", p0));
+    }
+
+    function logBytes7(bytes7 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes7)", p0));
+    }
+
+    function logBytes8(bytes8 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes8)", p0));
+    }
+
+    function logBytes9(bytes9 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes9)", p0));
+    }
+
+    function logBytes10(bytes10 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes10)", p0));
+    }
+
+    function logBytes11(bytes11 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes11)", p0));
+    }
+
+    function logBytes12(bytes12 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes12)", p0));
+    }
+
+    function logBytes13(bytes13 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes13)", p0));
+    }
+
+    function logBytes14(bytes14 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes14)", p0));
+    }
+
+    function logBytes15(bytes15 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes15)", p0));
+    }
+
+    function logBytes16(bytes16 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes16)", p0));
+    }
+
+    function logBytes17(bytes17 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes17)", p0));
+    }
+
+    function logBytes18(bytes18 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes18)", p0));
+    }
+
+    function logBytes19(bytes19 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes19)", p0));
+    }
+
+    function logBytes20(bytes20 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes20)", p0));
+    }
+
+    function logBytes21(bytes21 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes21)", p0));
+    }
+
+    function logBytes22(bytes22 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes22)", p0));
+    }
+
+    function logBytes23(bytes23 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes23)", p0));
+    }
+
+    function logBytes24(bytes24 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes24)", p0));
+    }
+
+    function logBytes25(bytes25 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes25)", p0));
+    }
+
+    function logBytes26(bytes26 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes26)", p0));
+    }
+
+    function logBytes27(bytes27 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes27)", p0));
+    }
+
+    function logBytes28(bytes28 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes28)", p0));
+    }
+
+    function logBytes29(bytes29 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes29)", p0));
+    }
+
+    function logBytes30(bytes30 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes30)", p0));
+    }
+
+    function logBytes31(bytes31 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes31)", p0));
+    }
+
+    function logBytes32(bytes32 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes32)", p0));
+    }
+
+    function log(uint256 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+    }
+
+    function log(string memory p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+    }
+
+    function log(bool p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+    }
+
+    function log(address p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+    }
+
+    function log(uint256 p0, uint256 p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint)", p0, p1));
+    }
+
+    function log(uint256 p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string)", p0, p1));
+    }
+
+    function log(uint256 p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool)", p0, p1));
+    }
+
+    function log(uint256 p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address)", p0, p1));
+    }
+
+    function log(string memory p0, uint256 p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint)", p0, p1));
+    }
+
+    function log(string memory p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
+    }
+
+    function log(string memory p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool)", p0, p1));
+    }
+
+    function log(string memory p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address)", p0, p1));
+    }
+
+    function log(bool p0, uint256 p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint)", p0, p1));
+    }
+
+    function log(bool p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string)", p0, p1));
+    }
+
+    function log(bool p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool)", p0, p1));
+    }
+
+    function log(bool p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address)", p0, p1));
+    }
+
+    function log(address p0, uint256 p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint)", p0, p1));
+    }
+
+    function log(address p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string)", p0, p1));
+    }
+
+    function log(address p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool)", p0, p1));
+    }
+
+    function log(address p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address)", p0, p1));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool)", p0, p1, p2));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool)", p0, p1, p2));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        uint256 p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        string memory p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        bool p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool)", p0, p1, p2));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        address p2
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address)", p0, p1, p2));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        uint256 p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        string memory p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        bool p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        uint256 p0,
+        address p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        uint256 p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        string memory p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        bool p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        string memory p0,
+        address p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        uint256 p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        string memory p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        bool p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        bool p0,
+        address p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        uint256 p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        string memory p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        bool p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        uint256 p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        uint256 p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        uint256 p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        uint256 p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        string memory p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        string memory p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        string memory p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        string memory p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        bool p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        bool p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        bool p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        bool p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        address p2,
+        uint256 p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        address p2,
+        string memory p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        address p2,
+        bool p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(
+        address p0,
+        address p1,
+        address p2,
+        address p3
+    ) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,address)", p0, p1, p2, p3));
+    }
+}

--- a/src/test/utils/Hevm.sol
+++ b/src/test/utils/Hevm.sol
@@ -16,4 +16,6 @@ abstract contract Hevm {
     ) public virtual;
 
     function ffi(string[] calldata) external virtual returns (bytes memory);
+
+    function expectRevert(bytes calldata) external virtual;
 }

--- a/src/vault/VaultFYActions.sol
+++ b/src/vault/VaultFYActions.sol
@@ -23,8 +23,12 @@ interface IFYToken {
     function redeem(address to, uint256 amount) external returns (uint256 redeemed);
 }
 
+/// @title VaultFYActions
+/// @notice A set of vault actions for modifying positions collateralized by Yield Protocol Fixed Yield Tokens
 contract VaultFYActions is Vault20Actions {
     using SafeERC20 for IERC20;
+
+    /// ======== Custom Errors ======== ///
 
     error VaultFYActions__buyCollateralAndModifyDebt_overflow();
     error VaultFYActions__buyCollateralAndModifyDebt_zeroUnderlierAmount();
@@ -36,10 +40,13 @@ contract VaultFYActions is Vault20Actions {
     error VaultFYActions__underlierToFYToken__overflow();
     error VaultFYActions__fyTokenToUnderlier__overflow();
 
+    /// ======== Types ======== ///
+
+    // Swap data
     struct SwapParams {
         // Min amount of asset out
         uint256 minAssetOut;
-        // Amount to approve
+        // Amount for the proxy to approve to allow safeTransferFrom
         uint256 approve;
         // Address of the yield space v2 pool
         address yieldSpacePool;
@@ -56,6 +63,22 @@ contract VaultFYActions is Vault20Actions {
         address publican_
     ) Vault20Actions(codex_, moneta_, fiat_, publican_) {}
 
+    /// ======== Position Management ======== ///
+
+    /// @notice Buys fyTokens from underliers before it modifies a Position's collateral
+    /// and debt balances and mints/burns FIAT using the underlier token.
+    /// The underlier is swapped to fyTokens and used as collateral.
+    /// @dev The user needs to previously approve the UserProxy for spending underlier tokens,
+    /// collateral tokens, or FIAT tokens. If `position` is not the UserProxy, the `position` owner
+    /// needs grant a delegate to UserProxy via Codex.
+    /// @param vault Address of the Vault
+    /// @param position Address of the position's owner
+    /// @param collateralizer Address of who puts up or receives the collateral delta as underlier tokens
+    /// @param creditor Address of who provides or receives the FIAT delta for the debt delta
+    /// @param underlierAmount Amount of underlier to swap for fyToken to put up for collateral [underlierScale]
+    /// @param deltaNormalDebt Amount of normalized debt (gross, before rate is applied) to generate (+) or
+    /// settle (-) on this Position [wad]
+    /// @param swapParams Parameters of the underlier to fyToken swap
     function buyCollateralAndModifyDebt(
         address vault,
         address position,
@@ -66,6 +89,7 @@ contract VaultFYActions is Vault20Actions {
         SwapParams calldata swapParams
     ) public {
         if (underlierAmount == 0) revert VaultFYActions__buyCollateralAndModifyDebt_zeroUnderlierAmount();
+        // Yield Space Contracts use uint128 for all amounts
         if (underlierAmount >= type(uint128).max) revert VaultFYActions__buyCollateralAndModifyDebt_overflow();
         // buy fyToken according to `swapParams` data and transfer tokens to be used as collateral into VaultFY
         uint256 fyTokenAmount = _buyFYToken(underlierAmount, collateralizer, swapParams);
@@ -84,6 +108,18 @@ contract VaultFYActions is Vault20Actions {
         );
     }
 
+    /// @notice Sells fyTokens for underliers after it modifies a Position's collateral and debt balances
+    /// and mints/burns FIAT using the underlier token. fyTokens cannot be sold after maturity, they should be redeemed.
+    /// @dev The user needs to previously approve the UserProxy for spending collateral tokens or FIAT tokens
+    /// If `position` is not the UserProxy, the `position` owner needs grant a delegate to UserProxy via Codex
+    /// @param vault Address of the Vault
+    /// @param position Address of the position's owner
+    /// @param collateralizer Address of who puts up or receives the collateral delta as underlier tokens
+    /// @param creditor Address of who provides or receives the FIAT delta for the debt delta
+    /// @param fyTokenAmount Amount of fyToken to remove as collateral and to swap for underlier [tokenScale]
+    /// @param deltaNormalDebt Amount of normalized debt (gross, before rate is applied) to generate (+) or
+    /// settle (-) on this Position [wad]
+    /// @param swapParams Parameters of the underlier to fyToken swap
     function sellCollateralAndModifyDebt(
         address vault,
         address position,
@@ -94,6 +130,7 @@ contract VaultFYActions is Vault20Actions {
         SwapParams calldata swapParams
     ) public {
         if (fyTokenAmount == 0) revert VaultFYActions__sellCollateralAndModifyDebt_zeroFYTokenAmount();
+        // Yield Space Contracts use uint128 for all amounts
         if (fyTokenAmount >= type(uint128).max) revert VaultFYActions__sellCollateralAndModifyDebt_overflow();
         int256 deltaCollateral = -toInt256(wdiv(fyTokenAmount, IVault(vault).tokenScale()));
 
@@ -113,6 +150,18 @@ contract VaultFYActions is Vault20Actions {
         _sellFYToken(fyTokenAmount, collateralizer, swapParams);
     }
 
+    /// @notice Redeems fyTokens for underliers after it modifies a Position's collateral
+    /// and debt balances and mints/burns FIAT using the underlier token. Fails if fyToken hasn't matured yet.
+    /// @dev The user needs to previously approve the UserProxy for spending collateral tokens or FIAT tokens
+    /// If `position` is not the UserProxy, the `position` owner needs grant a delegate to UserProxy via Codex
+    /// @param vault Address of the Vault
+    /// @param token Address of the collateral token (fyToken)
+    /// @param position Address of the position's owner
+    /// @param collateralizer Address of who puts up or receives the collateral delta as underlier tokens
+    /// @param creditor Address of who provides or receives the FIAT delta for the debt delta
+    /// @param fyTokenAmount Amount of fyToken to remove as collateral and to swap or redeem for underlier [tokenScale]
+    /// @param deltaNormalDebt Amount of normalized debt (gross, before rate is applied) to generate (+) or
+    /// settle (-) on this Position [wad]
     function redeemCollateralAndModifyDebt(
         address vault,
         address token,
@@ -138,9 +187,11 @@ contract VaultFYActions is Vault20Actions {
         address from,
         SwapParams calldata swapParams
     ) internal returns (uint256) {
+        // Asks Yield Math to calculate the expected amount of fyToken received for underlier
         uint128 minFYToken = IFYPool(swapParams.yieldSpacePool).sellBasePreview(uint128(underlierAmount));
         if (swapParams.minAssetOut > minFYToken) revert VaultFYActions__buyFYToken_slippageExceedsMinAmountOut();
         if (swapParams.approve != 0) {
+            // Approval for when the proxy holds the underlier so safeTransferFrom can be called
             IERC20(swapParams.assetIn).approve(address(this), swapParams.approve);
         }
         address fromParsed;
@@ -149,7 +200,9 @@ contract VaultFYActions is Vault20Actions {
         } else {
             fromParsed = from;
         }
+        // Performs transfer of underlier into yieldspace pool
         IERC20(swapParams.assetIn).safeTransferFrom(fromParsed, swapParams.yieldSpacePool, underlierAmount);
+        // Sells underlier for fyToken. fyToken are transferred to the proxy to be entered into a vault
         return uint256(IFYPool(swapParams.yieldSpacePool).sellBase(address(this), minFYToken));
     }
 
@@ -158,6 +211,7 @@ contract VaultFYActions is Vault20Actions {
         address to,
         SwapParams calldata swapParams
     ) internal returns (uint256) {
+        // Asks Yield Math to calculate the expected amount of underlier received for fyToken
         uint128 minUnderlier = IFYPool(swapParams.yieldSpacePool).sellFYTokenPreview(uint128(fyTokenAmount));
         if (swapParams.minAssetOut > minUnderlier) revert VaultFYActions__sellFYToken_slippageExceedsMinAmountOut();
         // Transfer from this contract to fypool
@@ -166,11 +220,20 @@ contract VaultFYActions is Vault20Actions {
     }
 
     /// ======== View Methods ======== ///
+
+    /// @notice Returns an amount of fyToken for a given an amount of the underlier token (e.g. USDC)
+    /// @param underlierAmount Amount of underlier to be used to by fyToken
+    /// @param yieldSpacePool Address of the underlier-fyToken LP
+    /// @return Amount of fyToken [tokenScale]
     function underlierToFYToken(uint256 underlierAmount, address yieldSpacePool) external view returns (uint256) {
         if (underlierAmount >= type(uint128).max) revert VaultFYActions__underlierToFYToken__overflow();
         return uint256(IFYPool(yieldSpacePool).sellBasePreview(uint128(underlierAmount)));
     }
 
+    /// @notice Returns an amount of underlier for a given an amount of the fyToken
+    /// @param fyTokenAmount Amount of fyToken to be traded for underlier
+    /// @param yieldSpacePool Address of the underlier-fyToken LP
+    /// @return Amount of underlier expected on trade [underlierScale]
     function fyTokenToUnderlier(uint256 fyTokenAmount, address yieldSpacePool) external view returns (uint256) {
         if (fyTokenAmount >= type(uint128).max) revert VaultFYActions__fyTokenToUnderlier__overflow();
         return uint256(IFYPool(yieldSpacePool).sellFYTokenPreview(uint128(fyTokenAmount)));

--- a/src/vault/VaultFYActions.sol
+++ b/src/vault/VaultFYActions.sol
@@ -191,14 +191,14 @@ contract VaultFYActions is Vault20Actions {
         // Yield Space Contracts use uint128 for all amounts
         if (swapParams.minAssetOut >= type(uint128).max) revert VaultFYActions__buyFYToken_overflow();
 
-        // if `from` is set to an external address then transfer amount to the proxy first
+        // if `from` is set to an external address then transfer directly to the Yield LP
         // requires `from` to have set an allowance for the proxy
         if (from != address(0) && from != address(this)) {
-            IERC20(swapParams.assetIn).safeTransferFrom(from, address(this), underlierAmount);
+            IERC20(swapParams.assetIn).safeTransferFrom(from, swapParams.yieldSpacePool, underlierAmount);
+        } else {
+            IERC20(swapParams.assetIn).safeTransfer(swapParams.yieldSpacePool, underlierAmount);
         }
 
-        // Performs transfer of underlier into yieldspace pool
-        IERC20(swapParams.assetIn).safeTransfer(swapParams.yieldSpacePool, underlierAmount);
         // Sells underlier for fyToken. fyToken are transferred to the proxy to be entered into a vault
         return uint256(IFYPool(swapParams.yieldSpacePool).sellBase(address(this), uint128(swapParams.minAssetOut)));
     }

--- a/src/vault/VaultFYActions.sol
+++ b/src/vault/VaultFYActions.sol
@@ -144,5 +144,22 @@ contract VaultFYActions is Vault20Actions {
         IERC20(swapParams.assetIn).safeTransfer(fyPool, fyTokenAmount);
         return IFYPool(fyPool).sellFYToken(to, minUnderlier);
     }
+
+    /// ======== View Methods ======== ///
+    function underlierToFYToken(
+        uint256 underlierAmount,
+        address yieldSpacePool
+    ) external view returns (uint256) {
+        if (underlierAmount >= MAX) return 0;
+        return uint256(IFYPool(yieldSpacePool).sellBasePreview(uint128(underlierAmount)));
+    }
+
+    function fyTokenToUnderlier(
+        uint256 fyTokenAmount,
+        address yieldSpacePool
+    ) external view returns (uint256) {
+        if (fyTokenAmount >= MAX) return 0;
+        return uint256(IFYPool(yieldSpacePool).sellFYTokenPreview(uint128(fyTokenAmount)));
+    }
 }
 

--- a/src/vault/VaultFYActions.sol
+++ b/src/vault/VaultFYActions.sol
@@ -65,7 +65,7 @@ contract VaultFYActions is Vault20Actions {
 
     /// @notice Buys fyTokens from underliers before it modifies a Position's collateral
     /// and debt balances and mints/burns FIAT using the underlier token.
-    /// The underlier is swapped to fyTokens and used as collateral.
+    /// The underlier is swapped to fyTokens and used as collateral. Buy must be before fyToken maturity.
     /// @dev The user needs to previously approve the UserProxy for spending underlier tokens,
     /// collateral tokens, or FIAT tokens. If `position` is not the UserProxy, the `position` owner
     /// needs grant a delegate to UserProxy via Codex.

--- a/src/vault/VaultFYActions.sol
+++ b/src/vault/VaultFYActions.sol
@@ -36,9 +36,6 @@ contract VaultFYActions is Vault20Actions {
     error VaultFYActions__underlierToFYToken__overflow();
     error VaultFYActions__fyTokenToUnderlier__overflow();
 
-    // Yield Space Contracts use uint128 for all amounts
-    uint256 public constant MAX = type(uint128).max;
-
     struct SwapParams {
         // Min amount of asset out
         uint256 minAssetOut;
@@ -69,7 +66,7 @@ contract VaultFYActions is Vault20Actions {
         SwapParams calldata swapParams
     ) public {
         if (underlierAmount == 0) revert VaultFYActions__buyCollateralAndModifyDebt_zeroUnderlierAmount();
-        if (underlierAmount >= MAX) revert VaultFYActions__buyCollateralAndModifyDebt_overflow();
+        if (underlierAmount >= type(uint128).max) revert VaultFYActions__buyCollateralAndModifyDebt_overflow();
         // buy fyToken according to `swapParams` data and transfer tokens to be used as collateral into VaultFY
         uint256 fyTokenAmount = _buyFYToken(underlierAmount, collateralizer, swapParams);
         int256 deltaCollateral = toInt256(wdiv(fyTokenAmount, IVault(vault).tokenScale()));
@@ -97,7 +94,7 @@ contract VaultFYActions is Vault20Actions {
         SwapParams calldata swapParams
     ) public {
         if (fyTokenAmount == 0) revert VaultFYActions__sellCollateralAndModifyDebt_zeroFYTokenAmount();
-        if (fyTokenAmount >= MAX) revert VaultFYActions__sellCollateralAndModifyDebt_overflow();
+        if (fyTokenAmount >= type(uint128).max) revert VaultFYActions__sellCollateralAndModifyDebt_overflow();
         int256 deltaCollateral = -toInt256(wdiv(fyTokenAmount, IVault(vault).tokenScale()));
 
         // withdraw fyToken from the position
@@ -170,12 +167,12 @@ contract VaultFYActions is Vault20Actions {
 
     /// ======== View Methods ======== ///
     function underlierToFYToken(uint256 underlierAmount, address yieldSpacePool) external view returns (uint256) {
-        if (underlierAmount >= MAX) revert VaultFYActions__underlierToFYToken__overflow();
+        if (underlierAmount >= type(uint128).max) revert VaultFYActions__underlierToFYToken__overflow();
         return uint256(IFYPool(yieldSpacePool).sellBasePreview(uint128(underlierAmount)));
     }
 
     function fyTokenToUnderlier(uint256 fyTokenAmount, address yieldSpacePool) external view returns (uint256) {
-        if (fyTokenAmount >= MAX) revert VaultFYActions__fyTokenToUnderlier__overflow();
+        if (fyTokenAmount >= type(uint128).max) revert VaultFYActions__fyTokenToUnderlier__overflow();
         return uint256(IFYPool(yieldSpacePool).sellFYTokenPreview(uint128(fyTokenAmount)));
     }
 }

--- a/src/vault/VaultFYActions.sol
+++ b/src/vault/VaultFYActions.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import {IERC20} from "openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {IVault} from "fiat/interfaces/IVault.sol";
+import {WAD, toInt256, wmul, wdiv, sub} from "fiat/utils/Math.sol";
+
+import {Vault20Actions} from "./Vault20Actions.sol";
+
+interface IFYPool {
+    function sellBasePreview(uint128 baseIn) external view returns(uint128);
+    function sellBase(address to, uint128 min) external returns(uint128);    
+    function sellFYTokenPreview(uint128 fyTokenIn) external view  returns(uint128);
+    function sellFYToken(address to, uint128 min) external returns(uint128);
+}
+
+interface IFYToken {
+    function redeem(address to, uint256 amount) external returns (uint256 redeemed);
+}
+
+contract VaultFYActions is Vault20Actions {
+    using SafeERC20 for IERC20;
+
+    error VaultFYActions__overflow();
+    error VaultFYActions__buyCollateralAndModifyDebt_zeroUnderlierAmount();
+    error VaultFYActions__sellCollateralAndModifyDebt_zeroFYTokenAmount();
+    error VaultFYActions__redeemCollateralAndModifyDebt_zeroFYTokenAmount();
+
+    // Yield Space Contracts use uint128 for all amounts
+    uint256 public constant MAX = type(uint128).max;
+
+    struct SwapParams {
+        // Address of the yield space v2 pool
+        address yieldSpacePool;
+        // Underlier token address when adding collateral and `collateral` when removing
+        address assetIn;
+        // Collateral token address when adding collateral and `underlier` when removing
+        address assetOut;
+    }
+
+    constructor(
+        address codex_,
+        address moneta_,
+        address fiat_,
+        address publican_
+    ) Vault20Actions(codex_, moneta_, fiat_, publican_) {}
+
+    function buyCollateralAndModifyDebt(
+        address vault,
+        address position,
+        address collateralizer,
+        address creditor,
+        uint256 underlierAmount,
+        int256 deltaNormalDebt,
+        SwapParams calldata swapParams
+    ) public {
+        if (underlierAmount == 0) revert VaultFYActions__buyCollateralAndModifyDebt_zeroUnderlierAmount();
+        if (underlierAmount >= MAX) revert VaultFYActions__overflow();
+        // buy fyToken according to `swapParams` data and transfer tokens to be used as collateral into VaultFY
+        uint128 fyTokenAmount = _buyFYToken(uint128(underlierAmount), collateralizer, swapParams);
+        int256 deltaCollateral = toInt256(wdiv(uint256(fyTokenAmount), IVault(vault).tokenScale()));
+
+        // enter fyToken and collateralize position
+        modifyCollateralAndDebt(
+            vault,
+            swapParams.assetOut,
+            0,
+            position,
+            address(this),
+            creditor,
+            deltaCollateral,
+            deltaNormalDebt
+        );
+    }
+
+    function sellCollateralAndModifyDebt(
+        address vault,
+        address position,
+        address collateralizer,
+        address creditor,
+        uint256 fyTokenAmount,
+        int256 deltaNormalDebt,
+        SwapParams calldata swapParams
+    ) public {
+        if (fyTokenAmount == 0) revert VaultFYActions__sellCollateralAndModifyDebt_zeroFYTokenAmount();
+        if (fyTokenAmount >= MAX) revert VaultFYActions__overflow();
+        int256 deltaCollateral = -toInt256(wdiv(fyTokenAmount, IVault(vault).tokenScale()));
+
+        // withdraw fyToken from the position
+        modifyCollateralAndDebt(
+            vault,
+            swapParams.assetIn,
+            0,
+            position,
+            address(this),
+            creditor,
+            deltaCollateral,
+            deltaNormalDebt
+        );
+
+        // sell fyToken according to `swapParams`
+        _sellFYToken(uint128(fyTokenAmount), collateralizer, swapParams);
+    }
+
+    function redeemCollateralAndModifyDebt(
+        address vault,
+        address token,
+        address position,
+        address collateralizer,
+        address creditor,
+        uint256 fyTokenAmount,
+        int256 deltaNormalDebt
+    ) public {
+        if (fyTokenAmount == 0) revert VaultFYActions__redeemCollateralAndModifyDebt_zeroFYTokenAmount();
+
+        int256 deltaCollateral = -toInt256(wdiv(fyTokenAmount, IVault(vault).tokenScale()));
+
+        // withdraw fyToken from the position
+        modifyCollateralAndDebt(vault, token, 0, position, address(this), creditor, deltaCollateral, deltaNormalDebt);
+
+        // redeem fyToken for underlier
+        IFYToken(token).redeem(collateralizer, fyTokenAmount);
+    }
+
+
+    function _buyFYToken(uint128 underlierAmount, address from, SwapParams calldata swapParams) internal returns(uint128) {
+        address fyPool = swapParams.yieldSpacePool;
+        // Todo: Maybe adjust minFYToken to account for slippage
+        uint128 minFYToken = IFYPool(fyPool).sellBasePreview(underlierAmount);
+        IERC20(swapParams.assetIn).safeTransferFrom(from, fyPool, underlierAmount);
+        return IFYPool(fyPool).sellBase(from, minFYToken);
+    }
+
+    function _sellFYToken(
+        uint128 fyTokenAmount,
+        address to,
+        SwapParams calldata swapParams
+    ) internal returns (uint256) {
+        address fyPool = swapParams.yieldSpacePool;
+        uint128 minUnderlier = IFYPool(fyPool).sellFYTokenPreview(fyTokenAmount);
+        // Transfer from this contract to fypool
+        IERC20(swapParams.assetIn).safeTransfer(fyPool, fyTokenAmount);
+        return IFYPool(fyPool).sellFYToken(to, minUnderlier);
+    }
+}
+


### PR DESCRIPTION
- Implements buy, sell, and redeem actions for Yield protocol's fixed yield tokens in the FIAT protocol.
- Swaps underlier/fytoken through the yield-space-v2 contracts.
- Redemptions after maturity are done directly in the ftToken erc20 contract.

Notes: Yield space uses uint128 for their token amounts. There is a check that the fiat actions cannot be over the max uint128 value or else it will revert with an overflow.

Todos:
- [x] Update yield protocol vault to new vault style (blocking tests)
- [x] Add tests for actions